### PR TITLE
Export the Canvas instance.

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,3 +228,4 @@ function createAreaBasedPalette(sourceImage, colorCount) {
 
 module.exports.getDominantColor = getDominantColor
 module.exports.createPalette = createPalette
+module.exports.Canvas = Canvas


### PR DESCRIPTION
We need the Canvas instance exported in order to work around node-canvas issue #487.

https://github.com/Automattic/node-canvas/issues/487

Users of `thief` will need to reference this same instance of Canvas in order for their code to work.
